### PR TITLE
Fix issue if 'archive' doesn't exist, and return extString instead of…

### DIFF
--- a/lib/sign.js
+++ b/lib/sign.js
@@ -170,7 +170,11 @@ function stageExtensionFolder(extString) {
       }
     });
 
-    return tempDir;
+    if (!fs.existsSync(`./archive`)) {
+      fs.mkdirSync(`./archive`);
+    }
+
+    return extString;
 
   } catch (err) {
     console.log(chalk.red(`   Error staging extension`));


### PR DESCRIPTION
Earlier pr was returning the wrong thing, should have been `extString`, not the name of the temp directory. Also needed to include creation of the archive folder if it didn't already exist.